### PR TITLE
disable vagrant-vbguest by default

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -21,4 +21,9 @@ Vagrant.configure(2) do |config|
   if Vagrant.has_plugin?("vagrant-cachier")
     config.cache.scope = :box
   end
+  if Vagrant.has_plugin?("vagrant-vbguest")
+    config.vbguest.auto_update = false
+    config.vbguest.no_install = true
+    config.vbguest.no_remote = true
+  end
 end


### PR DESCRIPTION
Same as for the ms-lifecycle project, I found it helpful to disable vbguest by default.
