### PR TITLE
Update docker-compose version to 1.8.1

### DIFF
--- a/ansible/roles/docker/tasks/main.yml
+++ b/ansible/roles/docker/tasks/main.yml
@@ -22,7 +22,7 @@
 
 - name: Docker Compose is present
   get_url:
-    url: https://github.com/docker/compose/releases/download/1.4.1/docker-compose-Linux-x86_64
+    url: https://github.com/docker/compose/releases/download/1.8.1/docker-compose-Linux-x86_64
     dest: /usr/local/bin/docker-compose
   tags: [docker]
 


### PR DESCRIPTION
I think we should update the docker-compose version to the latest stable release!
I've updated the ansible-playbook and tested and it worked well!

😄 
