### PR TITLE
Specify JVM memory

### DIFF
--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -37,6 +37,7 @@ integ:
   volumes:
     - ./src:/source/src
   environment:
+    - JAVA_OPTS=-Xmx512m -Xms256m
     - TEST_TYPE=integ
     - DOMAIN=$DOMAIN
 


### PR DESCRIPTION
Need to specify JVM memory for integ tests otherwise you may get this
error:

OpenJDK 64-Bit Server VM warning: INFO: os::commit_memory(0x00000000c5550000, 715849728, 0) failed;
error='Cannot allocate memory' (errno=12)

 There is insufficient memory for the Java Runtime Environment to continue.
 Native memory allocation (malloc) failed to allocate 715849728 bytes for committing reserved memory.
 An error report file with more information is saved as:
 /source/hs_err_pid64.log