### PR TITLE
Cannot add PPA: 'ppa:ansible/ansible'

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 echo "Installing Ansible..."
-apt-get install -y software-properties-common
-apt-add-repository ppa:ansible/ansible
-apt-get update
-apt-get install -y --force-yes ansible
+sudo apt-get install -y software-properties-common
+sudo apt-add-repository ppa:ansible/ansible
+sudo apt-get update
+sudo apt-get install -y --force-yes ansible


### PR DESCRIPTION
Ansible would not be initialized correctly without `sudo` in `bootstrap.sh`.

My vagrant log show below:

```
...
==> dev: stdin: is not a tty
==> dev: Installing Ansible...
==> dev: Reading package lists...
==> dev: Building dependency tree...
==> dev: Reading state information...
==> dev: software-properties-common is already the newest version.
==> dev: 0 upgraded, 0 newly installed, 0 to remove and 2 not upgraded.
==> dev: Cannot add PPA: 'ppa:ansible/ansible'.
==> dev: Please check that the PPA name or format is correct.
...

``` 