### PR TITLE
Upgrade docker-py to v1.6.0

### DIFF
--- a/ansible/roles/docker/tasks/main.yml
+++ b/ansible/roles/docker/tasks/main.yml
@@ -17,7 +17,7 @@
   tags: [docker]
 
 - name: Docker-py is present
-  pip: name=docker-py version=0.4.0 state=present
+  pip: name=docker-py version=1.6.0 state=present
   tags: [docker]
 
 - name: Docker Compose is present


### PR DESCRIPTION
docker-py v0.4.0 is too old to install.

My vagrant log shown:

```
==> dev: TASK [docker : Docker-py is present] *******************************************
==> dev: fatal: [localhost]: FAILED! => {"changed": false, "cmd": "/usr/bin/pip2 install docker-py==0.4.0", "failed": true, "msg": "stdout: Downloading/unpacking docker-py==0.4.0\n  Cannot fetch index base URL https://pypi.python.org/simple/\n  Could not find any downloads that satisfy the requirement docker-py==0.4.0\nCleaning up...\nNo distributions at all found for docker-py==0.4.0\nStoring debug log for failure in /root/.pip/pip.log\n"}
==> dev: 	to retry, use: --limit @/vagrant/ansible/dev.retry
==> dev:
```