### PR TITLE
Java base image is deprecated

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,18 @@
-FROM java
+FROM openjdk:8-jdk-alpine
 MAINTAINER Viktor Farcic "viktor@farcic.com"
 
 ENV DB_DBNAME books
 ENV DB_COLLECTION books
 ENV DB_HOST localhost
 
-COPY run.sh /run.sh
-RUN chmod +x /run.sh
+#COPY run.sh /run.sh
+#RUN chmod +x /run.sh
 
 COPY target/scala-2.10/books-ms-assembly-1.0.jar /bs.jar
 COPY client/components /client/components
 
-CMD ["/run.sh"]
+#CMD ["/run.sh"]
+CMD ["java","-jar","gs-spring-boot-docker-0.1.0.jar"]
 
-EXPOSE 8080
+
+EXPOSE 8084

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ COPY target/scala-2.10/books-ms-assembly-1.0.jar /bs.jar
 COPY client/components /client/components
 
 #CMD ["/run.sh"]
-CMD ["java","-jar","gs-spring-boot-docker-0.1.0.jar"]
+CMD ["java","-jar","bs.jar"]
 
 
 EXPOSE 8084

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,4 +15,4 @@ COPY client/components /client/components
 CMD ["java","-jar","bs.jar"]
 
 
-EXPOSE 8084
+EXPOSE 8080


### PR DESCRIPTION
Hello,

I find out that this Dockerfile used java as base image, which is currently deprecated and I want to suggest to use openjdk on alpine.
Also, I edited CMD to avoid calling external script and execute jar itself.

Hope it helps!