### PR TITLE
Change to fix ansible's deprecation warning:

### DIFF
--- a/ansible/dev.yml
+++ b/ansible/dev.yml
@@ -1,5 +1,5 @@
 - hosts: localhost
   remote_user: vagrant
-  sudo: yes
+  become_user: yes
   roles:
     - docker


### PR DESCRIPTION
==> dev:  [WARNING]: provided hosts list is empty, only localhost is available
==> dev: [DEPRECATION WARNING]: Instead of sudo/sudo_user, use become/become_user and
==> dev: make sure become_method is 'sudo' (default).
==> dev: This feature will be removed in a
==> dev: future release. Deprecation warnings can be disabled by setting

