### PR TITLE
Version of sbt changed to 0.13.13

### DIFF
--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -18,7 +18,7 @@ RUN echo "deb http://packages.linuxmint.com debian import" >> /etc/apt/sources.l
 # Mongo, NodeJS, Git, SBT, xvfb, FireFox, Chrome
 RUN apt-get update && \
     apt-get -y install wget bzip2 make g++ && \
-    apt-get -y --force-yes install --no-install-recommends mongodb nodejs git sbt xvfb firefox google-chrome-stable && \
+    apt-get -y --force-yes install --no-install-recommends mongodb nodejs git sbt=0.13.13 xvfb firefox google-chrome-stable && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
The commit is related to issue #33 (Dockerfile.test error). The newest version of sbt 0.13.15 released on 2017-04-09 depends on openjdk-8-jdk, but openjdk-8-jdk is not available in default apt repos for debian:jessie. Version 0.13.13 (that was the latest in the repo till ~2017-04-09) doesn't depends on openjdk-8-jdk and doesn't cause problem with building the docker image.