### PR TITLE
Fix test-fixture version issue when running bower install for BG deployment

### DIFF
--- a/client/bower.json
+++ b/client/bower.json
@@ -13,7 +13,7 @@
     "test-fixture": "PolymerElements/test-fixture#^1.0.0"
   },
   "resolutions": {
-    "test-fixture": "^3.0.0",
+    "test-fixture": "^2.0.0",
     "polymer": "^1.0.0",
     "webcomponentsjs": "^0.7.15",
     "iron-ajax": "^1.0.0",

--- a/client/bower.json
+++ b/client/bower.json
@@ -13,6 +13,7 @@
     "test-fixture": "PolymerElements/test-fixture#^1.0.0"
   },
   "resolutions": {
+    "test-fixture": "^2.0.0",
     "polymer": "^1.0.0",
     "webcomponentsjs": "^0.7.15",
     "iron-ajax": "^1.0.0",

--- a/client/bower.json
+++ b/client/bower.json
@@ -13,7 +13,7 @@
     "test-fixture": "PolymerElements/test-fixture#^1.0.0"
   },
   "resolutions": {
-    "test-fixture": "^2.0.0",
+    "test-fixture": "^3.0.0",
     "polymer": "^1.0.0",
     "webcomponentsjs": "^0.7.15",
     "iron-ajax": "^1.0.0",


### PR DESCRIPTION
On the blue-green branch, the test-fixture version is missing from bower.json.  So the BG deployment may be failed by the error message "ECONFLICT Unable to find suitable version for test-fixture",  so I think we should set test-fixture version explicitly in bower.json just like master branch. Please take a look at it, thanks.