### PR TITLE
Ansible get_url timeout=60. Useful in complex or slow networks

### DIFF
--- a/ansible/roles/docker/tasks/main.yml
+++ b/ansible/roles/docker/tasks/main.yml
@@ -24,6 +24,7 @@
   get_url:
     url: https://github.com/docker/compose/releases/download/1.11.1/docker-compose-Linux-x86_64
     dest: /usr/local/bin/docker-compose
+    timeout: 60
   tags: [docker]
 
 - name: Docker Compose permissions are set


### PR DESCRIPTION
Suggesting to increase timeout in ansible's get_url from default 10s to 60s due to error:

dev: fatal: [localhost]: FAILED! => {"changed": false, "dest": "/usr/local/bin/docker-compose", "msg": "Connection failure: **The read operation timed out**", "state": "absent", "url": "https://github.com/docker/compose/releases/download/1.11.1/docker-compose-Linux-x86_64"}
