### PR TITLE
Enforcing project sbt version (0.13.x) in order to enable compilation on boxes with recent sbt versions (i.e. 1.2.y / 1.3.z)

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.6
+sbt.version=0.13.13

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=0.13.6


### PR DESCRIPTION
note: sbt version 0.13.6 is chosen intentionally in order to align with sbt-assembly sbt version: https://github.com/sbt/sbt-assembly/blob/0.12.0/project/build.properties

Kind of overzealous, but you newer know with sbt :wink: 

Note: book is deprecated / discontinued (and hence this PR will likely stay as-is). 
However, it may come in handy for all tomb raiders out there :smile: 
 